### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,5 +1,9 @@
 name: Link Checker
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/fbuireu/email-signature/security/code-scanning/1](https://github.com/fbuireu/email-signature/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- The `actions/checkout` step requires `contents: read` to access the repository's files.
- The `create-issue-from-file` step requires `issues: write` to create issues.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions to that specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
