### PR TITLE
ci: normalize step names to sentence case

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -14,13 +14,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Link Checker
+      - name: Run link checker
         id: lychee
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           fail: true
           output: ./reports/link-checker-output.md
-      - name: Create Issue From File
+      - name: Create issue from file
         if: failure() && steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: Security Analysis with zizmor 🌈
+name: Security Analysis with zizmor
 on:
   push:
     branches: ["main"]
@@ -7,7 +7,7 @@ on:
 permissions: {}
 jobs:
   zizmor:
-    name: Run zizmor 🌈
+    name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -16,5 +16,5 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Run zizmor 🌈
+      - name: Run zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Pure rename pass. No behaviour changes, no version bumps, no logic touched.

## Why

Comparing the CI across the seven repos turned up the same concept spelled several different ways:

| Concept | Variants in the wild |
|---|---|
| Checkout | `Checkout` · `Checkout repository` · `Checkout Repository` |
| Dependencies | `Install dependencies` · `Install Dependencies` |
| pnpm | `Setup pnpm` · `Install pnpm` |
| E2E | `Run E2E tests` · `Run E2E Tests` |
| Playwright | `Install Playwright browsers` · `Install Playwright Browsers` · `Install Playwright browser` |
| Typecheck | `Typecheck` · `Type check` |
| `.nvmrc` guard | `Verify .nvmrc is present` · `Validate .nvmrc exists` |

## Convention

**Sentence case** — capital on the first word and proper nouns only. It was already the majority in every repo, so this moves the minority spellings rather than inventing a new house style.

`Setup pnpm` pairs with `Setup Node.js` and matches what the action is actually called (`pnpm/action-setup`).

Composite action metadata is unquoted and sentence case too, and descriptions drop redundant trailing clauses — a "prepare environment" action installing dependencies is what the name already says.

## What is *not* touched

**Job names.** Branch protection matches required status checks by job name; renaming them would silently drop the checks from the required set. Any job-name normalization needs the protection rules updated in the same move, so it is out of scope here.
